### PR TITLE
update to new atom version, '.editor' deprecated

### DIFF
--- a/keymaps/ruby-syntax-replacer.cson
+++ b/keymaps/ruby-syntax-replacer.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'cmd-alt-x': 'ruby-syntax-replacer:replace'


### PR DESCRIPTION
changed the syntax according to the documentation for version 0.176 https://atom.io/docs/latest/advanced/keymaps